### PR TITLE
adjusted formula to allow for level extension of Locale Magnification

### DIFF
--- a/common/src/main/java/io/github/artynova/mediaworks/enchantment/LocaleMagnificationEnchantment.java
+++ b/common/src/main/java/io/github/artynova/mediaworks/enchantment/LocaleMagnificationEnchantment.java
@@ -7,7 +7,6 @@ import net.minecraft.entity.player.PlayerEntity;
 
 public class LocaleMagnificationEnchantment extends CloakEnchantment {
     public static final int MAX_LEVEL = 3;
-    public static final int[] BONUSES = new int[]{8, 16, 32};
 
     public LocaleMagnificationEnchantment() {
         super(Rarity.VERY_RARE);
@@ -16,7 +15,7 @@ public class LocaleMagnificationEnchantment extends CloakEnchantment {
     public static int getAmbitIncrease(PlayerEntity player) {
         int level = Math.min(MAX_LEVEL, EnchantmentHelper.getLevel(MediaworksEnchantments.LOCALE_MAGNIFICATION.get(), player.getEquippedStack(EquipmentSlot.HEAD)));
         if (level <= 0) return 0;
-        return BONUSES[level - 1];
+        return 8*level+Math.max(0,8*level-16);
     }
 
     @Override


### PR DESCRIPTION
I am not sure about the performance impacts this might have on raycasting performance. Perhaps the limit for raycasting could grow more slowly than the limit for ambit. Or perhaps a pattern could be added to restrict how much of the enchantment gets used per cast, or even decrease your ambit below 32m. For now though, this would fix #11 